### PR TITLE
Set minimum size for MainWindow and clean its csharp code

### DIFF
--- a/WinUINotes/WinUINotes/MainWindow.xaml.cs
+++ b/WinUINotes/WinUINotes/MainWindow.xaml.cs
@@ -1,26 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace WinUINotes
 {
-    /// <summary>
-    /// An empty window that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class MainWindow : Window
     {
         public MainWindow()
@@ -31,6 +14,15 @@ namespace WinUINotes
             ExtendsContentIntoTitleBar = true;
             // Replace system title bar with the WinUI TitleBar.
             SetTitleBar(AppTitleBar);
+
+            // Create a new window presenter
+            OverlappedPresenter presenter = OverlappedPresenter.Create();
+            // Set the minimum width the window can be resized to
+            presenter.PreferredMinimumWidth = 320;
+            // Set the minimum height the window can be resized to
+            presenter.PreferredMinimumHeight = 240;
+            // Apply the presenter settings to the current AppWindow
+            AppWindow.SetPresenter(presenter);
         }
 
         private void AppTitleBar_BackRequested(TitleBar sender, object args)

--- a/WinUINotes/WinUINotes/MainWindow.xaml.cs
+++ b/WinUINotes/WinUINotes/MainWindow.xaml.cs
@@ -18,9 +18,9 @@ namespace WinUINotes
             // Create a new window presenter
             OverlappedPresenter presenter = OverlappedPresenter.Create();
             // Set the minimum width the window can be resized to
-            presenter.PreferredMinimumWidth = 320;
+            presenter.PreferredMinimumWidth = 440;
             // Set the minimum height the window can be resized to
-            presenter.PreferredMinimumHeight = 240;
+            presenter.PreferredMinimumHeight = 280;
             // Apply the presenter settings to the current AppWindow
             AppWindow.SetPresenter(presenter);
         }


### PR DESCRIPTION
## Description
- Updated to include `Microsoft.UI.Windowing` namespace and removed unused namespaces.
- Introduced `OverlappedPresenter` in the `MainWindow` constructor to set minimum window dimensions and apply these settings to the current AppWindow.

## Motivational Context
- Improved window display and cleaner code structure.
- Preventing the divide-by-zero issue in `UniformGridLayout` (see issue #3).